### PR TITLE
docs(README): fix npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Contact the developer at bitinix@gmail.com
 
 ## Get started
 ```bash
-npm install --save VIES-VAT
+npm install --save vies-vat
 ```
 
 #### Valid CountryCodes


### PR DESCRIPTION
the npm command seems to be case sensitive, so changed it to lowercase.
That way the installation does not fail, like it did with the all Caps version.